### PR TITLE
#55 keyboard shortcuts

### DIFF
--- a/skunkbooth/main.py
+++ b/skunkbooth/main.py
@@ -6,7 +6,7 @@ from time import time
 from typing import List, Tuple
 
 from asciimatics.effects import Print
-from asciimatics.event import KeyboardEvent
+from asciimatics.event import Event, KeyboardEvent
 from asciimatics.exceptions import ResizeScreenError, StopApplication
 from asciimatics.scene import Scene
 from asciimatics.screen import Screen
@@ -29,10 +29,10 @@ logging.basicConfig(
 )
 
 
-def global_shortcuts(event):
+def global_shortcuts(event: Event) -> None:
     """Event handler for global shortcuts"""
-    ctrlQCode = 17
-    ctrlWCode = 23
+    ctrlQCode = Screen.ctrl('q')
+    ctrlWCode = Screen.ctrl('w')
     if isinstance(event, KeyboardEvent):
         c = event.key_code
         # Stop on q, esc, ctrl+q and ctrl+w

--- a/skunkbooth/main.py
+++ b/skunkbooth/main.py
@@ -131,7 +131,21 @@ def main() -> None:
                     Scene([PreviewFrame(screen, model=image_selection)], -1, name="Preview")
                 ]
 
-                screen.set_scenes(scenes)
+                screen.set_scenes(scenes, unhandled_input=global_shortcuts)
+
+            if screen.current_scene == scenes[2]:
+                event = screen.get_event()
+                if isinstance(event, KeyboardEvent):
+                    c = event.key_code
+                    layout = fFrame._layouts[1]
+                    if c == screen.KEY_HOME:
+                        fFrame.switch_focus(layout, 0, 0)
+                    elif c == screen.KEY_END:
+                        fFrame.switch_focus(layout, 0, len(fFrame.filterList)-1)
+                    elif c == screen.KEY_PAGE_UP:
+                        fFrame.process_event(KeyboardEvent(screen.KEY_UP))
+                    elif c == screen.KEY_PAGE_DOWN:
+                        fFrame.process_event(KeyboardEvent(screen.KEY_DOWN))
 
             screen.draw_next_frame()
 

--- a/skunkbooth/main.py
+++ b/skunkbooth/main.py
@@ -133,20 +133,6 @@ def main() -> None:
 
                 screen.set_scenes(scenes, unhandled_input=global_shortcuts)
 
-            if screen.current_scene == scenes[2]:
-                event = screen.get_event()
-                if isinstance(event, KeyboardEvent):
-                    c = event.key_code
-                    layout = fFrame._layouts[1]
-                    if c == screen.KEY_HOME:
-                        fFrame.switch_focus(layout, 0, 0)
-                    elif c == screen.KEY_END:
-                        fFrame.switch_focus(layout, 0, len(fFrame.filterList)-1)
-                    elif c == screen.KEY_PAGE_UP:
-                        fFrame.process_event(KeyboardEvent(screen.KEY_UP))
-                    elif c == screen.KEY_PAGE_DOWN:
-                        fFrame.process_event(KeyboardEvent(screen.KEY_DOWN))
-
             screen.draw_next_frame()
 
             if webcam.image is not None and record[0]:

--- a/skunkbooth/main.py
+++ b/skunkbooth/main.py
@@ -6,6 +6,7 @@ from time import time
 from typing import List, Tuple
 
 from asciimatics.effects import Print
+from asciimatics.event import KeyboardEvent
 from asciimatics.exceptions import ResizeScreenError, StopApplication
 from asciimatics.scene import Scene
 from asciimatics.screen import Screen
@@ -26,6 +27,17 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s'
 )
+
+
+def global_shortcuts(event):
+    """Event handler for global shortcuts"""
+    ctrlQCode = 17
+    ctrlWCode = 23
+    if isinstance(event, KeyboardEvent):
+        c = event.key_code
+        # Stop on q, esc, ctrl+q and ctrl+w
+        if c in (Screen.KEY_ESCAPE, ord('q'), ctrlQCode, ctrlWCode):
+            raise StopApplication("User pressed quit")
 
 
 def main() -> None:
@@ -93,7 +105,7 @@ def main() -> None:
         Scene([fFrame], -1, name="Filters"),
         Scene([PreviewFrame(screen, model=image_selection)], -1, name="Preview")
     ]
-    screen.set_scenes(scenes)
+    screen.set_scenes(scenes, unhandled_input=global_shortcuts)
     b = a = 0
     while True:
         try:

--- a/skunkbooth/utils/frames.py
+++ b/skunkbooth/utils/frames.py
@@ -3,8 +3,10 @@ from datetime import datetime
 from typing import Any, Callable
 
 from asciimatics.effects import Effect, Print
+from asciimatics.event import Event, KeyboardEvent
 from asciimatics.exceptions import NextScene, StopApplication
 from asciimatics.renderers import Box, ColourImageFile, StaticRenderer
+from asciimatics.screen import Screen
 from asciimatics.widgets import (
     Button, CheckBox, FileBrowser, Frame, Label, Layout
 )
@@ -232,6 +234,25 @@ class FilterFrame(Frame):
                 self.filters.toggle(i[0].name)
         self.save()
         raise NextScene("Main")
+
+    def _skip_to_next_page(self) -> None:
+        """Function to skip to next page of filters"""
+        pass
+
+    def process_event(self, event: Event) -> None:
+        """Deals with keyboard events that happen in this screen"""
+        super(FilterFrame, self).process_event(event)
+        if isinstance(event, KeyboardEvent):
+            c = event.key_code
+            layout = self._layouts[1]
+            if c == Screen.KEY_HOME:
+                self.switch_focus(layout, 0, 0)
+            elif c == Screen.KEY_END:
+                self.switch_focus(layout, 0, len(self.filterList) - 1)
+            elif c == Screen.KEY_PAGE_UP:
+                pass
+            elif c == Screen.KEY_PAGE_DOWN:
+                pass
 
 
 class PreviewFrame(Frame):


### PR DESCRIPTION
Fixes #55 

I have added the global shortcut bindings to close the application (q, esc, ctrl+w and ctrl+q) as well as the navigational shortcuts for the filter screen (pgUp, pgDown, Home, End).

However, I am not sure how the ctrl+arrow keys shortcut should behave from the issue description. Should they behave similarly to the home and end keys in the filter screen? If you could please clarify this point, I'd be happy to go in and implement that final shortcut too. I hope everything else is right and up to standard :)
