### PR TITLE
Remove comment from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-    <!-- ![Image of skukbooth logo](Images/skunkbooth_readme.png) -->
 <div align="center">
    <img src="Images/skunkbooth_readme.png" alt="Skunkbooth Logo" width="143" height="143">
    <br/>


### PR DESCRIPTION
This removes the comment from `README.md`, which contained a link for SkunkBooth's logo.