### PR TITLE
Migrate from os.path to pathlib and fix some directory handling errors

### DIFF
--- a/skunkbooth/data/defaults.py
+++ b/skunkbooth/data/defaults.py
@@ -1,17 +1,18 @@
-from os import path
 from pathlib import Path
 
+SKUNKBOOTH_DIR = (Path.home() / "skunkbooth").absolute()
+
 _settings = {
-    "LOG_FILE": f"{Path.home()}/skunkbooth/.logs/skunkbooth.log",
-    "SETTINGS_FILE": f"{Path.home()}/skunkbooth/.settings/settings.conf",
-    "PIC_DIR": f"{Path.home()}/skunkbooth/pictures",
+    "LOG_FILE": f"{SKUNKBOOTH_DIR}/.logs/skunkbooth.log",
+    "SETTINGS_FILE": f"{SKUNKBOOTH_DIR}/.settings/settings.conf",
+    "PIC_DIR": f"{SKUNKBOOTH_DIR}/pictures",
     "IMG_FORMAT": "JPG",
     "LANGUAGE": "en"
 }
 
 
 for i in ["LOG_FILE", "PIC_DIR", "SETTINGS_FILE"]:
-    if i[-3:] == "DIR":
-        Path.mkdir(Path(path.abspath(_settings[i])), exist_ok=True)
-    else:
-        Path.mkdir(Path(path.dirname(path.abspath(_settings[i]))), exist_ok=True)
+    path = Path(_settings[i])
+    if i[-3:] != "DIR":
+        path = path.parent
+    path.mkdir(parents=True, exist_ok=True)

--- a/skunkbooth/utils/fileIO.py
+++ b/skunkbooth/utils/fileIO.py
@@ -1,6 +1,6 @@
 import logging
 from functools import lru_cache
-from os import path
+from pathlib import Path
 from sys import platform
 from typing import List, Tuple
 
@@ -20,12 +20,13 @@ class IOBase:
 
     def setFont(self, fp: str, size: int) -> None:
         """Set render font, fall back to Input if font name is invalid"""
-        fp = f'{path.join(path.dirname(path.abspath(__file__)), "..", "data", fp)}.ttf'
+        font_path = Path(__file__).absolute().parents[1] / "data"
+        fp = str(font_path / f"{fp}.ttf")
         try:
             self.font = ImageFont.truetype(fp, size)
         except OSError:
             logging.error(f"Font {fp} not found, falling back.")
-            fp = f'{path.join(path.dirname(path.abspath(__file__)), "..", "data", "Hack.ttf")}'
+            fp = str(font_path / "Hack.ttf")
             self.font = ImageFont.truetype(fp, size)
 
         px, py = self.fx, self.fy

--- a/skunkbooth/utils/filterManager.py
+++ b/skunkbooth/utils/filterManager.py
@@ -1,8 +1,7 @@
 import logging
 import sys
-from glob import glob
 from importlib import import_module
-from os.path import abspath, basename, dirname, join
+from pathlib import Path
 from typing import List, Tuple
 
 from PIL import Image
@@ -23,11 +22,12 @@ class filterManager:
     """
 
     def __init__(self):
-        sys.path.extend(abspath("filters"))
-        modules = glob(join(dirname(__file__), "..", "filters", "*.py"))
+        filters_path = Path(__file__).absolute().parents[1] / "filters"
+        sys.path.extend(f"{filters_path}")
+        modules = filters_path.glob("*.py")
         f = [
-            import_module(f"skunkbooth.filters.{basename(f)[:-3]}").filter()
-            for f in modules if "__init__.py" not in f
+            import_module(f"skunkbooth.filters.{f.name[:-3]}").filter()
+            for f in modules if "__init__.py" not in f.name
         ]
         self.pil, self.ascii = {}, {}
         for i in f:

--- a/skunkbooth/utils/logger.py
+++ b/skunkbooth/utils/logger.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 
 
@@ -8,11 +7,9 @@ class CustomLogger:
 
     def __init__(self, fileoutpath: str) -> None:
         """Initializing logging module"""
-        self.fileoutpath = fileoutpath
+        self.fileoutpath = Path(fileoutpath).absolute()
+        self.fileoutpath.parent.mkdir(parents=True, exist_ok=True)
 
-        Path.mkdir(
-            Path(os.path.dirname(os.path.abspath(__file__)) + os.sep + "Logs"), exist_ok=True
-        )
         logging.basicConfig(
             filename=self.fileoutpath,
             filemode="w",


### PR DESCRIPTION
Replaces `os.path` methods with `pathlib.Path`, and fixes some issues where directories didn't exist.
`CustomLogger` now creates the directory tree for the path provided.